### PR TITLE
PPII-1348 Duplicate Approver  in Level 1 and Level 2 When Updating an…

### DIFF
--- a/app/(afterLogin)/(employeeInformation)/employees/settings/approvals/_component/editWorkFLow/index.tsx
+++ b/app/(afterLogin)/(employeeInformation)/employees/settings/approvals/_component/editWorkFLow/index.tsx
@@ -70,13 +70,6 @@ const EditWorkFLow = () => {
         onSuccess: () => {
           setEditModal(false);
         },
-        onError: (error: any) => {
-          NotificationMessage.error({
-            message: 'Error',
-            description:
-              error?.response?.data?.message ?? 'Something went wrong',
-          });
-        },
       },
     );
   };

--- a/app/(afterLogin)/(employeeInformation)/employees/settings/approvals/_component/editWorkFLow/index.tsx
+++ b/app/(afterLogin)/(employeeInformation)/employees/settings/approvals/_component/editWorkFLow/index.tsx
@@ -1,5 +1,4 @@
 import EditApproverComponent from '@/components/Approval/editApprover';
-import NotificationMessage from '@/components/common/notification/notificationMessage';
 import {
   useDeleteApprover,
   useDeleteParallelApprover,

--- a/app/(afterLogin)/(timesheetInformation)/timesheet/settings/approvals/_component/editWorkFLow/index.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/settings/approvals/_component/editWorkFLow/index.tsx
@@ -70,13 +70,6 @@ const EditWorkFLow = () => {
         onSuccess: () => {
           setEditModal(false);
         },
-        onError: (error: any) => {
-          NotificationMessage.error({
-            message: 'Error',
-            description:
-              error?.response?.data?.message ?? 'Something went wrong',
-          });
-        },
       },
     );
   };

--- a/app/(afterLogin)/(timesheetInformation)/timesheet/settings/approvals/_component/editWorkFLow/index.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/settings/approvals/_component/editWorkFLow/index.tsx
@@ -1,5 +1,4 @@
 import EditApproverComponent from '@/components/Approval/editApprover';
-import NotificationMessage from '@/components/common/notification/notificationMessage';
 import {
   useDeleteApprover,
   useDeleteParallelApprover,

--- a/app/(afterLogin)/(tna)/tna/settings/approvals/_component/editWorkFlow/index.tsx
+++ b/app/(afterLogin)/(tna)/tna/settings/approvals/_component/editWorkFlow/index.tsx
@@ -70,13 +70,6 @@ const EditWorkFLow = () => {
         onSuccess: () => {
           setEditModal(false);
         },
-        onError: (error: any) => {
-          NotificationMessage.error({
-            message: 'Error',
-            description:
-              error?.response?.data?.message ?? 'Something went wrong',
-          });
-        },
       },
     );
   };

--- a/app/(afterLogin)/(tna)/tna/settings/approvals/_component/editWorkFlow/index.tsx
+++ b/app/(afterLogin)/(tna)/tna/settings/approvals/_component/editWorkFlow/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 import EditApproverComponent from '@/components/Approval/editApprover';
-import NotificationMessage from '@/components/common/notification/notificationMessage';
 import {
   useDeleteApprover,
   useDeleteParallelApprover,

--- a/store/server/features/approver/mutation.ts
+++ b/store/server/features/approver/mutation.ts
@@ -177,6 +177,13 @@ export const useUpdateAssignedUserMutation = () => {
           description: 'Approver updated successfully ',
         });
       },
+      onError: (error: any) => {
+        const errorMessage = error?.response?.data?.message || 'Something went wrong';
+        NotificationMessage.error({
+          message: 'Error',
+          description: errorMessage,
+        });
+      },
     },
   );
 };
@@ -192,6 +199,13 @@ export const useAddApproverMutation = () => {
         NotificationMessage.success({
           message: 'Successfully Created',
           description: 'Approver created successfully',
+        });
+      },
+      onError: (error: any) => {
+        const errorMessage = error?.response?.data?.message || 'Something went wrong';
+        NotificationMessage.error({
+          message: 'Error',
+          description: errorMessage,
         });
       },
     },

--- a/store/server/features/tna/training/mutation.ts
+++ b/store/server/features/tna/training/mutation.ts
@@ -177,6 +177,13 @@ export const useUpdateAssignedUserMutation = () => {
           description: 'Approver updated successfully ',
         });
       },
+      onError: (error: any) => {
+        const errorMessage = error?.response?.data?.message || 'Something went wrong';
+        NotificationMessage.error({
+          message: 'Error',
+          description: errorMessage,
+        });
+      },
     },
   );
 };
@@ -192,6 +199,13 @@ export const useAddApproverMutation = () => {
         NotificationMessage.success({
           message: 'Successfully Created',
           description: 'Approver created successfully',
+        });
+      },
+      onError: (error: any) => {
+        const errorMessage = error?.response?.data?.message || 'Something went wrong';
+        NotificationMessage.error({
+          message: 'Error',
+          description: errorMessage,
         });
       },
     },


### PR DESCRIPTION
…d creating  Approval Workflow   should show notification existed approver(learning and growth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error notifications for certain actions in approvals and training modules, ensuring users are informed when updates or additions fail.
  * Error notifications are no longer shown in specific workflow edit screens for employees, timesheets, and TNA approvals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->