### PR TITLE
PPII-1398 Enhance Filters component to ensure onSearch is triggered o…

### DIFF
--- a/app/(afterLogin)/(payroll)/payroll/_components/filters/index.tsx
+++ b/app/(afterLogin)/(payroll)/payroll/_components/filters/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { Col, Row, Select } from 'antd';
 import { useGetAllFiscalYears } from '@/store/server/features/organizationStructure/fiscalYear/queries';
 import { useGetAllUsers } from '@/store/server/features/employees/employeeManagment/queries';
@@ -51,6 +51,7 @@ const Filters: React.FC<FiltersProps> = ({
   const [sessions, setSessions] = useState<any[]>([]);
   const [months, setMonths] = useState<any[]>([]);
   const { setMonthId, setYearId, setSessionId } = useTnaReviewStore();
+  const initialSearchTriggered = useRef(false);
 
   useEffect(() => {
     setMonthId(searchValue.monthId);
@@ -86,12 +87,20 @@ const Filters: React.FC<FiltersProps> = ({
           setSessions(selectedYear.sessions || []);
           setMonths(selectedSession?.months || []);
 
-          setSearchValue((prev) => ({
-            ...prev,
-            yearId: prev.yearId || selectedYear.id || '',
-            sessionId: prev.sessionId || selectedSession?.id || '',
-            monthId: prev.monthId || selectedMonth?.id || '',
-          }));
+          const newSearchValue = {
+            ...searchValue,
+            yearId: selectedYear.id || '',
+            sessionId: selectedSession?.id || '',
+            monthId: selectedMonth?.id || '',
+          };
+
+          setSearchValue(newSearchValue);
+
+          // Only trigger onSearch once on mount
+          if (!initialSearchTriggered.current) {
+            onSearch(newSearchValue);
+            initialSearchTriggered.current = true;
+          }
         }
       } else {
         // If yearId/sessionId/monthId are already set, update sessions/months for the selected year/session


### PR DESCRIPTION
…nly once on initial mount and improve search value updates for year, session, and month selections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the initial search in the payroll filters, ensuring search is triggered exactly once when fiscal year data is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->