### PR TITLE
PPII-1486 "Email Reminder" sends to all approvers instead of the sele…

### DIFF
--- a/app/(afterLogin)/(timesheetInformation)/timesheet/leave-management/leaves/page.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/leave-management/leaves/page.tsx
@@ -100,7 +100,14 @@ const LeaveManagement = () => {
                 id="emailNotification"
                 className={isSmallScreen ? 'w-10 h-10' : ''}
                 icon={<MdMarkEmailRead size={20} />}
-                onClick={() => sendNotification()}
+                onClick={() => {
+                  const selectedIds = selectedRowKeys.length > 0 
+                    ? selectedRowKeys.map((key) => key.toString())
+                    : undefined;
+                        sendNotification({
+                          leaveRequestIds: selectedIds
+                        });
+                }}
                 loading={isLoading}
               />
               <Popover

--- a/app/(afterLogin)/dashboard/_components/approval-status/approval-status-card.tsx
+++ b/app/(afterLogin)/dashboard/_components/approval-status/approval-status-card.tsx
@@ -6,6 +6,7 @@ import {
   useSetApproveLeaveRequest,
   useSetFinalApproveBranchRequest,
   useSetFinalApproveLeaveRequest,
+  useSetAllLeaveRequestNotification,
 } from '@/store/server/features/timesheet/leaveRequest/mutation';
 import { useAuthenticationStore } from '@/store/uistate/features/authentication';
 import { useGetEmployee } from '@/store/server/features/employees/employeeDetail/queries';
@@ -51,6 +52,7 @@ const ApprovalRequestCard: FC<ApprovalRequestCardProps> = ({
     mutate: finalBranchApprover,
     isLoading: isLoadingFinalBranchApprover,
   } = useSetFinalApproveBranchRequest();
+  const { mutate: sendNotification } = useSetAllLeaveRequestNotification();
   const tenantId = useAuthenticationStore.getState().tenantId;
   const { userId } = useAuthenticationStore();
   const userRollId = useAuthenticationStore.getState().userData.roleId;
@@ -115,6 +117,13 @@ const ApprovalRequestCard: FC<ApprovalRequestCardProps> = ({
             finalLeaveApproval({
               leaveRequestId: e.requestId,
               status: 'approved',
+            });
+          }
+        } else {
+          // If not the final approval, send notification to next approver ONLY for Leave requests
+          if (requestType == 'Leave') {
+            sendNotification({
+              leaveRequestIds: [e.requestId],
             });
           }
         }

--- a/store/server/features/timesheet/leaveRequest/interface.ts
+++ b/store/server/features/timesheet/leaveRequest/interface.ts
@@ -19,6 +19,10 @@ export interface LeaveRequestStatusBody {
   status: 'approved' | 'declined';
 }
 
+export interface LeaveRequestNotificationBody {
+  leaveRequestIds?: string[];
+}
+
 export interface AllLeaveRequestApproveData {
   userId: string;
   roleId: string;

--- a/store/server/features/timesheet/leaveRequest/mutation.ts
+++ b/store/server/features/timesheet/leaveRequest/mutation.ts
@@ -12,6 +12,7 @@ import { requestHeader } from '@/helpers/requestHeader';
 import {
   AllLeaveRequestApproveData,
   LeaveRequestStatusBody,
+  LeaveRequestNotificationBody,
 } from '@/store/server/features/timesheet/leaveRequest/interface';
 import NotificationMessage from '@/components/common/notification/notificationMessage';
 
@@ -127,12 +128,13 @@ const setAllFinalApproveLeaveRequest = async (data: any) => {
     data,
   });
 };
-const setAllLeaveRequestNotification = async () => {
+const setAllLeaveRequestNotification = async (data?: LeaveRequestNotificationBody) => {
   const requestHeaders = await requestHeader();
   return await crudRequest({
     url: `${TIME_AND_ATTENDANCE_URL}/leave-request/current-approver/pending-leaves/notify`,
     method: 'POST',
     headers: requestHeaders,
+    data,
   });
 };
 export const useSetLeaveRequest = () => {


### PR DESCRIPTION
…cted leave requests only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email Reminder now supports selecting specific leave requests to notify; if none are selected, a general reminder is sent.
  * After a non-final approval on a Leave request, the next approver is automatically notified, improving handoffs and speed; final-approval behavior remains unchanged.
  * Added support for targeted leave notifications to enable more precise reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->