### PR TITLE
Add reset functionality for benefit entitlement sidebar

### DIFF
--- a/app/(afterLogin)/(compensation)/benefit/[id]/_components/benefitEntitlementSidebarEdit.tsx
+++ b/app/(afterLogin)/(compensation)/benefit/[id]/_components/benefitEntitlementSidebarEdit.tsx
@@ -32,6 +32,7 @@ const BenefitEntitlementSideBarEdit = ({ title }: BenefitEntitlementProps) => {
     setSettlementPeriod,
     data,
     setData,
+    setEditBenefitData,
   } = useBenefitEntitlementStore();
 
   const { mutate: updateBenefitEntitlement, isLoading: updateBenefitLoading } =
@@ -46,6 +47,9 @@ const BenefitEntitlementSideBarEdit = ({ title }: BenefitEntitlementProps) => {
   const onClose = () => {
     form.resetFields();
     setData([]);
+    setTotalAmount(0);
+    setSettlementPeriod(0);
+    setEditBenefitData(null);
     setIsBenefitEntitlementSidebarUpdateOpen(false);
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the Benefit Entitlement sidebar now fully clears form inputs, including total amount and settlement period, and removes any in-progress edits. This prevents stale data from reappearing when reopening the sidebar, reduces confusion, and helps avoid accidental submissions with outdated values for a more consistent editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->