### PR TITLE
PPII-1479-hide-tna-and-my-tna-from-learning-and-growth

### DIFF
--- a/components/navBar/index.tsx
+++ b/components/navBar/index.tsx
@@ -358,13 +358,13 @@ const Nav: React.FC<MyComponentProps> = ({ children }) => {
       permissions: ['view_learning_growth'],
       disabled: hasEndedFiscalYear || isSubscriptionExpired,
       children: [
-        {
-          title: <span>My-TNA</span>,
-          key: '/tna/my-training',
-          className: 'font-bold',
-          permissions: ['view_my_training'],
-          disabled: hasEndedFiscalYear || isSubscriptionExpired,
-        },
+        // {
+        //   title: <span>My-TNA</span>,
+        //   key: '/tna/my-training',
+        //   className: 'font-bold',
+        //   permissions: ['view_my_training'],
+        //   disabled: hasEndedFiscalYear || isSubscriptionExpired,
+        // },
         {
           title: <span>Training Management</span>,
           key: '/tna/management',
@@ -372,13 +372,13 @@ const Nav: React.FC<MyComponentProps> = ({ children }) => {
           permissions: ['manage_training'],
           disabled: hasEndedFiscalYear || isSubscriptionExpired,
         },
-        {
-          title: <span>TNA</span>,
-          key: '/tna/review',
-          className: 'font-bold',
-          permissions: ['view_tna_review'],
-          disabled: hasEndedFiscalYear || isSubscriptionExpired,
-        },
+        // {
+        //   title: <span>TNA</span>,
+        //   key: '/tna/review',
+        //   className: 'font-bold',
+        //   permissions: ['view_tna_review'],
+        //   disabled: hasEndedFiscalYear || isSubscriptionExpired,
+        // },
         {
           title: <span>Settings</span>,
           key: '/tna/settings/course-category',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated top navigation: temporarily hid two sub-menu items under Learning & Growth > TNA—My-TNA and TNA Review. Parent TNA menu remains available; no changes to access rules or routing elsewhere. Users will no longer see or access these two sub-options from the menu. No other sections were modified in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->