### PR TITLE
fixing department lead issue

### DIFF
--- a/app/(afterLogin)/(employeeInformation)/employees/manage-employees/_components/allFormData/jobTimeLineForm/index.tsx
+++ b/app/(afterLogin)/(employeeInformation)/employees/manage-employees/_components/allFormData/jobTimeLineForm/index.tsx
@@ -65,6 +65,8 @@ const JobTimeLineForm: React.FC<JobTimeLineFormProps> = ({ employeeData }) => {
 
   const handleDepartmentChange = (value: string) => {
     setSelectedDepartmentId(value);
+    setSwitchValue(false);
+    form.setFieldValue('departmentLeadOrNot', false);
   };
 
   const handleTeamLeadChange = (checked: boolean) => {

--- a/app/(afterLogin)/(employeeInformation)/employees/manage-employees/_components/formData/index.ts
+++ b/app/(afterLogin)/(employeeInformation)/employees/manage-employees/_components/formData/index.ts
@@ -44,7 +44,7 @@ export const transformData = (data: any) => {
       effectiveEndDate: formatDate(data.effectiveEndDate),
       employementTypeId: data.employementTypeId,
       departmentId: data.departmentId,
-      departmentLeadOrNot: data.departmentLeadOrNot ?? true,
+      departmentLeadOrNot: data.departmentLeadOrNot ?? false,
       employmentContractType: data.employmentContractType,
       workScheduleId: data.workScheduleId,
       basicSalary: Number(data.basicSalary),
@@ -54,7 +54,6 @@ export const transformData = (data: any) => {
     },
   };
 
-  // Append the categorized JSON data to formData
   formData.append('createUserDto', JSON.stringify(result.createUserDto));
   formData.append(
     'createRolePermissionDto',
@@ -77,7 +76,6 @@ export const transformData = (data: any) => {
     JSON.stringify(result.createEmployeeDocumentDto),
   );
 
-  // Append files separately
   if (data.profileImage?.file?.originFileObj) {
     formData.append('profileImage', data.profileImage.file.originFileObj);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Department Lead selection now resets when the department changes, preventing the previous department’s lead state from persisting.

- Changes
  - Default for “Department Lead” is now off when creating job information, unless explicitly selected.

- Chores
  - Removed redundant inline comments with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->