### PR TITLE
Fix file path assignment in BreakImportSidebar component

### DIFF
--- a/app/(afterLogin)/(timesheetInformation)/timesheet/employee-attendance/_components/breakImportSidebar/index.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/employee-attendance/_components/breakImportSidebar/index.tsx
@@ -168,7 +168,7 @@ const BreakImportSidebar = () => {
                 fileUpload(file as File)
                   .then((res: any) => {
                     setIsLoading(false);
-                    setFilePath(res.data['viewImage']);
+                    setFilePath(res['viewImage']);
                     onSuccess && onSuccess(res, file);
                   })
                   .catch((err: any) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the break import sidebar where successful uploads could appear to fail or not display the uploaded image/preview. The upload flow now correctly interprets the server response, ensuring the file path is saved and previews/loading states update reliably. No changes to public APIs or visible component structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->