### PR TITLE
Add leave balance expiring feature to user leave balance components

### DIFF
--- a/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/adminPanel/UserLeaveBalance.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/adminPanel/UserLeaveBalance.tsx
@@ -15,6 +15,8 @@ import { useGetLeaveBalance } from '@/store/server/features/timesheet/leaveBalan
 import { TimeAndAttendaceDashboardStore } from '@/store/uistate/features/timesheet/dashboard';
 import { useGetEmployees } from '@/store/server/features/employees/employeeManagment/queries';
 import dayjs from 'dayjs';
+import { useGetLeaveBalanceExpiring } from '@/store/server/features/timesheet/leaveExpiry/queries';
+
 
 const UserLeaveBalance: React.FC = () => {
   const [form] = Form.useForm();
@@ -29,6 +31,9 @@ const UserLeaveBalance: React.FC = () => {
     setEndDate,
     setUserIdOnLeaveBalance,
     userIdOnLeaveBalance,
+    monthsAheadOnLeaveBalanceExpiring,
+    setMonthsAheadOnLeaveBalanceExpiring,
+      
   } = TimeAndAttendaceDashboardStore();
 
   const { data: userLeaveBalance, isLoading: userLeaveBalanceLoading } =
@@ -42,6 +47,14 @@ const UserLeaveBalance: React.FC = () => {
     useGetLeaveBalance(
       userIdOnLeaveBalance ? userIdOnLeaveBalance : (userId as string),
       '',
+    );
+    const {
+      data: leaveBalanceExpiring,
+      isLoading: leaveBalanceExpiringLoading,
+    } = useGetLeaveBalanceExpiring(
+      userId as string,
+      leaveTypeId || '',
+      monthsAheadOnLeaveBalanceExpiring,
     );
 
   const statusColors: { [key: string]: string } = {
@@ -195,7 +208,7 @@ const UserLeaveBalance: React.FC = () => {
                 </span>
               </div>
             </div>
-            <div className="py-4">
+            <div className="py-4 md:border-b border-r border[3px] border-gray-200">
               <div className="flex items-center justify-center gap-4 px-4">
                 <span className="text-[16px] text-black font-medium text-right w-32">
                   Total Utilized
@@ -205,6 +218,43 @@ const UserLeaveBalance: React.FC = () => {
                     userLeaveBalance?.data?.totals?.totalUtilizedLeaves,
                   )?.toLocaleString() || 0}
                 </span>
+              </div>
+            </div>
+            <div className="py-4">
+              <div className="flex items-center justify-center md:gap-4 gap-2 md:px-4 px-2  ">
+                <span className="md:text-[16px] text-[10px] text-black font-medium text-right md:w-32">
+                  About to expire
+                </span>
+                <span className="md:text-[16px] text-[14px] font-bold text-black md:w-20">
+                  {Number.isNaN(
+                    Number(leaveBalanceExpiring?.totalExpiringAmount),
+                  )
+                    ? '-'
+                    : Number(
+                        leaveBalanceExpiring?.totalExpiringAmount,
+                      )?.toLocaleString() || 0}
+                </span>
+              </div>
+              <div className="flex items-center justify-center md:gap-4 gap-2 md:px-4 px-2">
+                <Select
+                  loading={leaveBalanceExpiringLoading}
+                  value={Number(monthsAheadOnLeaveBalanceExpiring)}
+                  size="small"
+                  className="w-30"
+                  onSelect={(value: number) => {
+                    setMonthsAheadOnLeaveBalanceExpiring(String(value));
+                  }}
+                >
+                  {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                    <Select.Option
+                      key={month}
+                      value={month}
+                      label={`${month} ${month === 1 ? 'Month' : 'Months'}`}
+                    >
+                      In {month} {month === 1 ? 'Month' : 'Months'}
+                    </Select.Option>
+                  ))}
+                </Select>
               </div>
             </div>
           </div>

--- a/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/adminPanel/UserLeaveBalance.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/adminPanel/UserLeaveBalance.tsx
@@ -245,7 +245,9 @@ const UserLeaveBalance: React.FC = () => {
                     setMonthsAheadOnLeaveBalanceExpiring(String(value));
                   }}
                 >
+                  {/*  eslint-disable-next-line @typescript-eslint/naming-convention */}
                   {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                    /*  eslint-enable-next-line @typescript-eslint/naming-convention */
                     <Select.Option
                       key={month}
                       value={month}

--- a/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/personal/MyleaveBalance.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/personal/MyleaveBalance.tsx
@@ -1,4 +1,4 @@
-import { Card,Select, Skeleton, Spin, Tag, Tooltip } from 'antd';
+import { Card, Select, Skeleton, Spin, Tag, Tooltip } from 'antd';
 import React from 'react';
 import { useGetUserLeaveBalance } from '@/store/server/features/timesheet/dashboard/queries';
 import { TimeAndAttendaceDashboardStore } from '@/store/uistate/features/timesheet/dashboard';
@@ -9,8 +9,14 @@ import { useGetLeaveBalanceExpiring } from '@/store/server/features/timesheet/le
 const MyleaveBalance: React.FC = () => {
   const { userId } = useAuthenticationStore();
 
-  const { leaveTypeId, startDate, endDate, setLeaveTypeId, monthsAheadOnLeaveBalanceExpiring, setMonthsAheadOnLeaveBalanceExpiring } =
-    TimeAndAttendaceDashboardStore();
+  const {
+    leaveTypeId,
+    startDate,
+    endDate,
+    setLeaveTypeId,
+    monthsAheadOnLeaveBalanceExpiring,
+    setMonthsAheadOnLeaveBalanceExpiring,
+  } = TimeAndAttendaceDashboardStore();
   const { data: userLeaveBalance, isLoading: userLeaveBalanceLoading } =
     useGetUserLeaveBalance(
       userId as string,
@@ -20,10 +26,8 @@ const MyleaveBalance: React.FC = () => {
     );
   const { data: leaveBalance, isLoading: leaveBalanceLoading } =
     useGetLeaveBalance(userId as string, '');
-    const {
-      data: leaveBalanceExpiring,
-      isLoading: leaveBalanceExpiringLoading,
-    } = useGetLeaveBalanceExpiring(
+  const { data: leaveBalanceExpiring, isLoading: leaveBalanceExpiringLoading } =
+    useGetLeaveBalanceExpiring(
       userId as string,
       leaveTypeId || '',
       monthsAheadOnLeaveBalanceExpiring,
@@ -160,7 +164,9 @@ const MyleaveBalance: React.FC = () => {
                     setMonthsAheadOnLeaveBalanceExpiring(String(value));
                   }}
                 >
+                  {/*  eslint-disable-next-line @typescript-eslint/naming-convention */}
                   {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                    /*  eslint-enable-next-line @typescript-eslint/naming-convention */
                     <Select.Option
                       key={month}
                       value={month}

--- a/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/personal/MyleaveBalance.tsx
+++ b/app/(afterLogin)/(timesheetInformation)/timesheet/dashboard/_components/personal/MyleaveBalance.tsx
@@ -1,14 +1,15 @@
-import { Card, Skeleton, Spin, Tag, Tooltip } from 'antd';
+import { Card,Select, Skeleton, Spin, Tag, Tooltip } from 'antd';
 import React from 'react';
 import { useGetUserLeaveBalance } from '@/store/server/features/timesheet/dashboard/queries';
 import { TimeAndAttendaceDashboardStore } from '@/store/uistate/features/timesheet/dashboard';
 import { useGetLeaveBalance } from '@/store/server/features/timesheet/leaveBalance/queries';
 import { useAuthenticationStore } from '@/store/uistate/features/authentication';
 import dayjs from 'dayjs';
-
+import { useGetLeaveBalanceExpiring } from '@/store/server/features/timesheet/leaveExpiry/queries';
 const MyleaveBalance: React.FC = () => {
   const { userId } = useAuthenticationStore();
-  const { leaveTypeId, startDate, endDate, setLeaveTypeId } =
+
+  const { leaveTypeId, startDate, endDate, setLeaveTypeId, monthsAheadOnLeaveBalanceExpiring, setMonthsAheadOnLeaveBalanceExpiring } =
     TimeAndAttendaceDashboardStore();
   const { data: userLeaveBalance, isLoading: userLeaveBalanceLoading } =
     useGetUserLeaveBalance(
@@ -19,6 +20,14 @@ const MyleaveBalance: React.FC = () => {
     );
   const { data: leaveBalance, isLoading: leaveBalanceLoading } =
     useGetLeaveBalance(userId as string, '');
+    const {
+      data: leaveBalanceExpiring,
+      isLoading: leaveBalanceExpiringLoading,
+    } = useGetLeaveBalanceExpiring(
+      userId as string,
+      leaveTypeId || '',
+      monthsAheadOnLeaveBalanceExpiring,
+    );
   const statusColors: { [key: string]: string } = {
     approved: 'text-[#3636F0] bg-[#B2B2FF]',
     pending: 'text-[#FFD023] bg-[#FFDE6533]',
@@ -114,7 +123,7 @@ const MyleaveBalance: React.FC = () => {
                 </span>
               </div>
             </div>
-            <div className="py-4">
+            <div className="py-4 md:border-b border-r border[3px] border-gray-200">
               <div className="flex items-center justify-center gap-4 px-4">
                 <span className="text-[16px] text-black font-medium text-right w-32">
                   Total Utilized
@@ -124,6 +133,43 @@ const MyleaveBalance: React.FC = () => {
                     userLeaveBalance?.data?.totals?.totalUtilizedLeaves,
                   )?.toLocaleString() || 0}
                 </span>
+              </div>
+            </div>
+            <div className="py-4">
+              <div className="flex items-center justify-center md:gap-4 gap-2 md:px-4 px-2  ">
+                <span className="md:text-[16px] text-[10px] text-black font-medium text-right md:w-32">
+                  About to expire
+                </span>
+                <span className="md:text-[16px] text-[14px] font-bold text-black md:w-20">
+                  {Number.isNaN(
+                    Number(leaveBalanceExpiring?.totalExpiringAmount),
+                  )
+                    ? '-'
+                    : Number(
+                        leaveBalanceExpiring?.totalExpiringAmount,
+                      )?.toLocaleString() || 0}
+                </span>
+              </div>
+              <div className="flex items-center justify-center md:gap-4 gap-2 md:px-4 px-2">
+                <Select
+                  loading={leaveBalanceExpiringLoading}
+                  value={Number(monthsAheadOnLeaveBalanceExpiring)}
+                  size="small"
+                  className="w-30"
+                  onSelect={(value: number) => {
+                    setMonthsAheadOnLeaveBalanceExpiring(String(value));
+                  }}
+                >
+                  {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                    <Select.Option
+                      key={month}
+                      value={month}
+                      label={`${month} ${month === 1 ? 'Month' : 'Months'}`}
+                    >
+                      In {month} {month === 1 ? 'Month' : 'Months'}
+                    </Select.Option>
+                  ))}
+                </Select>
               </div>
             </div>
           </div>

--- a/store/server/features/timesheet/leaveExpiry/queries.ts
+++ b/store/server/features/timesheet/leaveExpiry/queries.ts
@@ -1,0 +1,30 @@
+import { crudRequest } from '@/utils/crudRequest';
+import { TIME_AND_ATTENDANCE_URL } from '@/utils/constants';
+import { useQuery } from 'react-query';
+import { requestHeader } from '@/helpers/requestHeader';
+
+const getLeaveBalanceExpiring = async (
+  userId: string,
+  leaveTypeId: string,
+  monthsAhead: string,
+) => {
+  const requestHeaders = await requestHeader();
+  return await crudRequest({
+    url: `${TIME_AND_ATTENDANCE_URL}/leave-balance/expiring`,
+    method: 'GET',
+    headers: requestHeaders,
+    params: { userId, leaveTypeId, monthsAhead },
+  });
+};
+export const useGetLeaveBalanceExpiring = (
+  userId: string,
+  leaveTypeId: string,
+  monthsAhead: string,
+) =>
+  useQuery<any>(
+    ['leave-balance-expiring', userId, leaveTypeId, monthsAhead],
+    () => getLeaveBalanceExpiring(userId, leaveTypeId, monthsAhead),
+    {
+      enabled: !!userId && !!leaveTypeId && !!monthsAhead,
+    },
+  );

--- a/store/uistate/features/timesheet/dashboard/index.ts
+++ b/store/uistate/features/timesheet/dashboard/index.ts
@@ -58,6 +58,8 @@ export interface TimeAndAttendanceDashboardUseState {
   currentStatusOnAttendance: string;
   setCurrentStatusOnAttendance: (currentStatusOnAttendance: string) => void;
   // handleSearchChange:(item:string,value:any)=>void;
+  monthsAheadOnLeaveBalanceExpiring: string;
+  setMonthsAheadOnLeaveBalanceExpiring: (monthsAheadOnLeaveBalanceExpiring: string) => void;
 }
 
 export const TimeAndAttendaceDashboardStore =
@@ -138,4 +140,7 @@ export const TimeAndAttendaceDashboardStore =
     currentStatusOnAttendance: '',
     setCurrentStatusOnAttendance: (currentStatusOnAttendance: string) =>
       set({ currentStatusOnAttendance }),
+    monthsAheadOnLeaveBalanceExpiring: '3',
+    setMonthsAheadOnLeaveBalanceExpiring: (monthsAheadOnLeaveBalanceExpiring: string) =>
+      set({ monthsAheadOnLeaveBalanceExpiring }),
   }));


### PR DESCRIPTION
- Integrated `useGetLeaveBalanceExpiring` hook in `UserLeaveBalance.tsx` and `MyleaveBalance.tsx` to fetch leave balances that are about to expire.
- Added UI elements to display the total expiring leave balance and a dropdown to select months ahead for expiration.
- Updated state management in `TimeAndAttendaceDashboardStore` to handle months ahead for expiring leave balances.
- Created a new query file `queries.ts` for handling leave balance expiration requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “About to expire” leave balance display showing total expiring amount.
  - Added a selector to choose the lookahead window (1–12 months; default 3) that updates views.
  - Visible in both Admin panel and My Leave Balance views.

- Improvements
  - Loading indicators while fetching expiring balance data.
  - Minor layout and styling tweaks (borders/padding) to integrate the new section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->